### PR TITLE
replace book of mistakes live link with memento

### DIFF
--- a/src/documents/index.html
+++ b/src/documents/index.html
@@ -174,7 +174,7 @@ layout: 'default'
                     </p>
                 </div>
                 <div>
-                    <a href="//unmonastery-wiki.mirelsol.org/doku.php?id=book_of_mistakes" target="_blank" class="btn btn-lg btn-outline-lt">
+                    <a href="//web.archive.org/web/20160601091857/http://unmonastery-wiki.mirelsol.org:80/doku.php?id=book_of_mistakes" target="_blank" class="btn btn-lg btn-outline-lt">
                         The Book
                     </a>
                 </div>


### PR DESCRIPTION
the book of mistakes was using a dokuwiki instance which has since been shut down

this replaces its link with one to an archived snapshot of said page